### PR TITLE
Line chart tooltips

### DIFF
--- a/charts/linechart.mjs
+++ b/charts/linechart.mjs
@@ -77,6 +77,7 @@ export default class LineChart {
     this.y = d3.scaleLinear().rangeRound([this.height, 0])
     this.xAxis = null
     this.yAxis = null
+    this.xVar = 
     this.color = d3.scaleOrdinal().range(this.colors)
     this.min = null
     this.max = null
@@ -502,6 +503,7 @@ export default class LineChart {
 
   drawHoverFeature() {
     const self = this
+    const xColumn = this.xColumn
     const $hoverLine = this.$features
       .append("line")
       .attr("x1", 0)
@@ -521,11 +523,12 @@ export default class LineChart {
     // handle mouse hover event
     $hoverLayerRect
       .on("mousemove touchmove", function (d) {
-        const bisectDate = d3.bisector(d => d.date).left,
+        
+        const bisectDate = d3.bisector(d => d[xColumn]).left,
           x0 = self.x.invert(d3.mouse(this)[0]),
           i = bisectDate(self.data, x0, 1),
           tooltipData = {
-            data: { date: x0 }
+            data: { [xColumn]: x0 }
           }
 
         self.keys.forEach((key) => {
@@ -534,18 +537,18 @@ export default class LineChart {
             d1 = data[i]
           
           if (d0 && d1) {
-            d = x0 - d0.date > d1.date - x0 ? d1 : d0
+            d = x0 - d0[xColumn] > d1[xColumn] - x0 ? d1 : d0
           } else {
             d = d0
           }
 
           // remove spacing in keys
-          tooltipData.data[key.replace(/\s+/g, "")] = d[key]
+          // tooltipData.data[key.replace(/\s+/g, "")] = d[key]
+          tooltipData.data[key] = d[key]
         })
 
-
         // render html using mustache
-        const text = mustache(self.tooltipTemplate, { ...helpers, ...tooltipData })
+        const text = mustache(self.tooltipTemplate, { ...helpers, ...tooltipData.data })
         self.$tooltip.html(text)
         
         // render tooltip from left or right depending on mouse position

--- a/charts/linechart.mjs
+++ b/charts/linechart.mjs
@@ -106,7 +106,7 @@ export default class LineChart {
 
     // parse optionalKey
     if (this.userKey.length > 1) {
-      this.userKey.forEach(function (d) {
+      this.userKey.forEach((d) => {
         this.optionalKey[d.key] = d.colour
       })
     }
@@ -598,17 +598,18 @@ export default class LineChart {
       .enter()
       .append("line")
         .attr("class", "annotationLine")
-        .attr("x1", function (d) {
+        .attr("x1", (d) => {
           return this.x(d.x)
         })
-        .attr("y1", function (d) {
+        .attr("y1", (d) => {
           return this.y(d.y)
         })
-        .attr("x2", function (d) {
+        .attr("x2", (d) => {
           return this.x(d.x)
         })
-        .attr("y2", function (d) {
-          return this.y(d.offset)
+        .attr("y2", (d) => {
+          const yPos = this.y(d.offset)
+          return yPos <= -15 ? -15 : yPos
         })
         .style("opacity", 1)
         .attr("stroke", "#000")
@@ -618,10 +619,10 @@ export default class LineChart {
         .data(this.labels)
         .enter().append("circle")
         .attr("class", "annotationCircle")
-        .attr("cy", function (d) {
+        .attr("cy", (d) => {
           return this.y(d.offset) + textPadding(d) / 2
         })
-        .attr("cx", function (d) {
+        .attr("cx", (d) => {
           return this.x(d.x)
         })
         .attr("r", 8)
@@ -631,16 +632,16 @@ export default class LineChart {
         .data(this.labels)
         .enter().append("text")
         .attr("class", "annotationTextMobile")
-        .attr("y", function (d) {
+        .attr("y", (d) => {
           return this.y(d.offset) + textPaddingMobile(d)
         })
-        .attr("x", function (d) {
+        .attr("x", (d) => {
           return this.x(d.x)
         })
         .style("text-anchor", "middle")
         .style("opacity", 1)
         .attr("fill", "#FFF")
-        .text(function (d, i) {
+        .text((d, i) => {
           return i + 1
         })
       
@@ -650,7 +651,7 @@ export default class LineChart {
           .text("Notes: ")
       }
 
-      this.labels.forEach(function (d, i) {
+      this.labels.forEach((d, i) => {
         $footerAnnotations.append("span")
           .attr("class", "annotationFooterNumber")
           .text(i + 1 + " - ")
@@ -666,25 +667,28 @@ export default class LineChart {
         }
       })
     } else {
-
-      this.$features.selectAll(".annotationText")
+      this.$features
+        .selectAll(".annotationText2")
         .data(this.labels)
-        .enter().append("text")
-        .attr("class", "annotationText")
-        .attr("y", function (d) {
-          console.log(textPadding(d))
-          return this.y(d.offset) + -1*textPadding(d)
-        })
-        .attr("x", function (d) {
-          return this.x(d.x)
-        })
-        .style("text-anchor", function (d) {
-          return d.align
-        })
-        .style("opacity", 1)
-        .text(function (d) {
-          return d.text
-        })
+        .enter()
+        .append("text")
+          .attr("class", "annotationText2")
+          .attr("y", (d) => {
+            const yPos = this.y(d.offset)
+            return yPos <= -10 ? -10 : yPos + -1*textPadding(d)
+          })
+          .attr("x", (d) => {
+            const yPos = this.y(d.offset)
+            const xPos = this.x(d.x)
+            return yPos <= -10 ? xPos - 5 : xPos
+          })
+          .style("text-anchor", (d) => {
+            return d.align
+          })
+          .style("opacity", 1)
+          .text((d) => {
+            return d.text
+          })
     }
   }
 }

--- a/dist/chartcss/scatterplot.css
+++ b/dist/chartcss/scatterplot.css
@@ -186,6 +186,20 @@ html {
   #outer-wrapper .dot-label {
     fill: #767676;
     font-size: 10px; }
+  #outer-wrapper .subTitle {
+    font-size: 1rem;
+    color: #808080;
+    font-weight: bold;
+    font-family: 'Guardian Text Sans Web', 'Agate Sans', sans-serif; }
+  #outer-wrapper .footer {
+    font-size: 12px;
+    line-height: 16px;
+    color: #767676;
+    font-family: 'Guardian Text Sans Web', 'Helvetica Neue', Helvetica, Arial, 'Lucida Grande', sans-serif; }
+  #outer-wrapper .chartNotes {
+    font-size: 0.9rem;
+    color: #767676;
+    font-family: 'Guardian Text Sans Web', 'Agate Sans', sans-serif; }
   #outer-wrapper .center {
     margin-right: auto;
     margin-left: auto;

--- a/src/main.scss
+++ b/src/main.scss
@@ -117,3 +117,17 @@ padding-left: 60px;
 	.buttonWrapper {
 		    margin-bottom: 10px;
 	}}
+
+	.tooltip {
+		position: absolute !important;
+		width: 150px;
+		pointer-events: none;
+		background-color: white;
+		border: 1px;
+		border-color: black;
+		border-style: solid;
+		padding: 10px;
+		font-family: 'Guardian Text Sans Web', 'Helvetica Neue', Helvetica, Arial, 'Lucida Grande', sans-serif;
+		font-size: 12px;
+		line-height: 14px;
+	}

--- a/src/modules/charts/linechart.js
+++ b/src/modules/charts/linechart.js
@@ -93,7 +93,7 @@ var LineChart = /*#__PURE__*/function () {
     this.y = d3.scaleLinear().rangeRound([this.height, 0]);
     this.xAxis = null;
     this.yAxis = null;
-    this.color = d3.scaleOrdinal().range(this.colors);
+    this.xVar = this.color = d3.scaleOrdinal().range(this.colors);
     this.min = null;
     this.max = null;
     this.lineGenerators = {};
@@ -402,19 +402,18 @@ var LineChart = /*#__PURE__*/function () {
     key: "drawHoverFeature",
     value: function drawHoverFeature() {
       var self = this;
+      var xColumn = this.xColumn;
       var $hoverLine = this.$features.append("line").attr("x1", 0).attr("y1", 0).attr("x2", 0).attr("y2", this.height).style("opacity", 0).style("stroke", "#333").style("stroke-dasharray", 4);
       var $hoverLayerRect = this.$features.append("rect").attr("width", this.width).attr("height", this.height).style("opacity", 0); // handle mouse hover event
 
       $hoverLayerRect.on("mousemove touchmove", function (d) {
         var bisectDate = d3.bisector(function (d) {
-          return d.date;
+          return d[xColumn];
         }).left,
             x0 = self.x.invert(d3.mouse(this)[0]),
             i = bisectDate(self.data, x0, 1),
             tooltipData = {
-          data: {
-            date: x0
-          }
+          data: (0, _defineProperty2["default"])({}, xColumn, x0)
         };
         self.keys.forEach(function (key) {
           var data = self.chartKeyData[key],
@@ -422,16 +421,17 @@ var LineChart = /*#__PURE__*/function () {
               d1 = data[i];
 
           if (d0 && d1) {
-            d = x0 - d0.date > d1.date - x0 ? d1 : d0;
+            d = x0 - d0[xColumn] > d1[xColumn] - x0 ? d1 : d0;
           } else {
             d = d0;
           } // remove spacing in keys
+          // tooltipData.data[key.replace(/\s+/g, "")] = d[key]
 
 
-          tooltipData.data[key.replace(/\s+/g, "")] = d[key];
+          tooltipData.data[key] = d[key];
         }); // render html using mustache
 
-        var text = (0, _mustache["default"])(self.tooltipTemplate, _objectSpread({}, _helpers["default"], {}, tooltipData));
+        var text = (0, _mustache["default"])(self.tooltipTemplate, _objectSpread({}, _helpers["default"], {}, tooltipData.data));
         self.$tooltip.html(text); // render tooltip from left or right depending on mouse position
 
         var tipWidth = document.querySelector("#tooltip").getBoundingClientRect().width;

--- a/src/modules/charts/linechart.js
+++ b/src/modules/charts/linechart.js
@@ -125,7 +125,7 @@ var LineChart = /*#__PURE__*/function () {
 
       if (this.userKey.length > 1) {
         this.userKey.forEach(function (d) {
-          this.optionalKey[d.key] = d.colour;
+          _this.optionalKey[d.key] = d.colour;
         });
       } // ?
 
@@ -452,6 +452,8 @@ var LineChart = /*#__PURE__*/function () {
   }, {
     key: "drawAnnotation",
     value: function drawAnnotation() {
+      var _this3 = this;
+
       function textPadding(d) {
         return d.offset > 0 ? 6 : -2;
       }
@@ -463,25 +465,27 @@ var LineChart = /*#__PURE__*/function () {
       var $footerAnnotations = d3.select("#footerAnnotations");
       $footerAnnotations.html("");
       this.$features.selectAll(".annotationLine").data(this.labels).enter().append("line").attr("class", "annotationLine").attr("x1", function (d) {
-        return this.x(d.x);
+        return _this3.x(d.x);
       }).attr("y1", function (d) {
-        return this.y(d.y);
+        return _this3.y(d.y);
       }).attr("x2", function (d) {
-        return this.x(d.x);
+        return _this3.x(d.x);
       }).attr("y2", function (d) {
-        return this.y(d.offset);
+        var yPos = _this3.y(d.offset);
+
+        return yPos <= -15 ? -15 : yPos;
       }).style("opacity", 1).attr("stroke", "#000");
 
       if (this.isMobile) {
         this.$features.selectAll(".annotationCircles").data(this.labels).enter().append("circle").attr("class", "annotationCircle").attr("cy", function (d) {
-          return this.y(d.offset) + textPadding(d) / 2;
+          return _this3.y(d.offset) + textPadding(d) / 2;
         }).attr("cx", function (d) {
-          return this.x(d.x);
+          return _this3.x(d.x);
         }).attr("r", 8).attr("fill", "#000");
         this.$features.selectAll(".annotationTextMobile").data(this.labels).enter().append("text").attr("class", "annotationTextMobile").attr("y", function (d) {
-          return this.y(d.offset) + textPaddingMobile(d);
+          return _this3.y(d.offset) + textPaddingMobile(d);
         }).attr("x", function (d) {
-          return this.x(d.x);
+          return _this3.x(d.x);
         }).style("text-anchor", "middle").style("opacity", 1).attr("fill", "#FFF").text(function (d, i) {
           return i + 1;
         });
@@ -493,18 +497,23 @@ var LineChart = /*#__PURE__*/function () {
         this.labels.forEach(function (d, i) {
           $footerAnnotations.append("span").attr("class", "annotationFooterNumber").text(i + 1 + " - ");
 
-          if (i < this.labels.length - 1) {
+          if (i < _this3.labels.length - 1) {
             $footerAnnotations.append("span").attr("class", "annotationFooterText").text(d.text + ", ");
           } else {
             $footerAnnotations.append("span").attr("class", "annotationFooterText").text(d.text);
           }
         });
       } else {
-        this.$features.selectAll(".annotationText").data(this.labels).enter().append("text").attr("class", "annotationText").attr("y", function (d) {
-          console.log(textPadding(d));
-          return this.y(d.offset) + -1 * textPadding(d);
+        this.$features.selectAll(".annotationText2").data(this.labels).enter().append("text").attr("class", "annotationText2").attr("y", function (d) {
+          var yPos = _this3.y(d.offset);
+
+          return yPos <= -10 ? -10 : yPos + -1 * textPadding(d);
         }).attr("x", function (d) {
-          return this.x(d.x);
+          var yPos = _this3.y(d.offset);
+
+          var xPos = _this3.x(d.x);
+
+          return yPos <= -10 ? xPos - 5 : xPos;
         }).style("text-anchor", function (d) {
           return d.align;
         }).style("opacity", 1).text(function (d) {

--- a/src/modules/utilities/helpers.js
+++ b/src/modules/utilities/helpers.js
@@ -14,6 +14,13 @@ var helpers = {
   
   nicerdate: function() {
     return moment(this.data.index).format('MMM D')
+  },
+
+  // format date as month day (i.e. Jan 30)
+  // - value should be a valid date string
+  formatDate: function (value, render) {
+    var date = new Date(render(value));
+    return moment(date).format("MMM D");
   }
 
 }


### PR DESCRIPTION
## What does this change?
Add tooltips to the line chart. A first pass on the refactor of the line chart module. 

## How to test
1. using `key`: `country-comparison-covid-2020` and `location`: `yacht-charter-data`
2. provide a tooltip template in the 'template'
```
 <strong>{{#formatDate}}{{data.date}}{{/formatDate}}</strong><br/>
          Australia: {{data.Australia}}<br/>
          France: {{data.France}}<br/>
          Germany: {{data.Germany}}<br/>
          Italy: {{data.Italy}}<br/>
          Sweden: {{data.Sweden}}<br/>
          United Kingdom: {{data.UnitedKingdom}}<br/>
```

## How can we measure success?
when mouse is hovered on the chart:
* tooltip div appears
* tooltip line appears
* tooltip div and line follows the mouse
* tooltip displays the data accordingly to the template and the data displayed is correct

## Have we considered potential risks?
More testing with existing line charts

## Images
<img width="1335" alt="Screen Shot 2020-11-22 at 11 32 02 am" src="https://user-images.githubusercontent.com/349944/99890729-624fd080-2cb6-11eb-95cb-c39adfdc819d.png">

